### PR TITLE
Update nav links to integrate applets with projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
           <ul class="nav-list">
             <li><a href="./index.html" class="active">Home</a></li>
             <li><a href="./projects.html">Projects</a></li>
-            <li><a href="./applets/index.html">Applets</a></li>
             <li><a href="#about">About</a></li>
             <li><a href="#contact">Contact</a></li>
           </ul>

--- a/projects.html
+++ b/projects.html
@@ -147,7 +147,6 @@
             <li><a href="./projects.html" class="active">Projects</a></li>
             <li><a href="./index.html#about">About</a></li>
             <li><a href="./index.html#contact">Contact</a></li>
-            <li><a href="./applets/index.html">Applets</a></li>
           </ul>
         </nav>
         <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation">

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Jack Kinney Portfolio
 // Provides basic caching and offline functionality
 
-const CACHE_NAME = 'jtk-portfolio-v1.1.0'; // <-- Incremented version number
+const CACHE_NAME = 'jtk-portfolio-v1.1.1'; // <-- Incremented version number
 const urlsToCache = [
   '/',
   '/index.html',
@@ -10,7 +10,6 @@ const urlsToCache = [
   '/assets/js/main.js',
   '/assets/images/profile.jpg',
   '/manifest.json',
-  '/applets/index.html',
   '/applets/graph-laplacian/index.html',
   '/applets/graph-laplacian/graph-engine.js',
   '/applets/graph-laplacian/visualizer.js',


### PR DESCRIPTION
## Summary
- remove Applets from site navigation
- drop Applets index from service worker cache
- bump service worker cache version

## Testing
- `npm test` *(fails: Need to install htmlhint@1.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_684754bf32e8832cb4ad28d6ae334561